### PR TITLE
fixed "file not found" error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def read(*filenames, **kwargs):
             buf.append(f.read())
     return sep.join(buf)
 
-long_description = read('README.txt', 'CHANGES.txt')
+long_description = read('README.md')
 
 
 class PyTest(TestCommand):


### PR DESCRIPTION
a issue on installing using pip

```
$ pip install git+https://github.com/mmattes/ptpip
Collecting git+https://github.com/mmattes/ptpip
  Cloning https://github.com/mmattes/ptpip to /private/var/folders/ty/tnmd__m11vlg9hcjms4csxp00000gn/T/pip-261Gqd-build
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/ty/tnmd__m11vlg9hcjms4csxp00000gn/T/pip-261Gqd-build/setup.py", line 19, in <module>
        long_description = read('README.txt', 'CHANGES.txt')
      File "/private/var/folders/ty/tnmd__m11vlg9hcjms4csxp00000gn/T/pip-261Gqd-build/setup.py", line 15, in read
        with io.open(filename, encoding=encoding) as f:
    IOError: [Errno 2] No such file or directory: 'README.txt'
```